### PR TITLE
add warn rule creation flow

### DIFF
--- a/src/components/buttons/settings-warn-create-rule.js
+++ b/src/components/buttons/settings-warn-create-rule.js
@@ -1,14 +1,28 @@
-const { MessageFlags } = require('discord.js');
+const {
+  ModalBuilder,
+  TextInputBuilder,
+  TextInputStyle,
+  ActionRowBuilder
+} = require('discord.js');
 
 module.exports = {
   customId: 'settings:warn-create-rule',
   
-  async execute(interaction, _args, client) {
-    // Placeholder for creating new warn rules
-    // This would typically open a modal or show a form
-    await interaction.reply({
-      content: '⚠️ Функция создания правил находится в разработке.',
-      flags: MessageFlags.Ephemeral
-    });
+  async execute(interaction) {
+    const modal = new ModalBuilder()
+      .setCustomId(`settings:warn-create-rule-modal:${interaction.message.id}`)
+      .setTitle('Создать правило');
+
+    const nameInput = new TextInputBuilder()
+      .setCustomId('label')
+      .setLabel('Название правила')
+      .setStyle(TextInputStyle.Short)
+      .setRequired(true);
+
+    modal.addComponents(
+      new ActionRowBuilder().addComponents(nameInput),
+    );
+
+    await interaction.showModal(modal);
   }
 };

--- a/src/components/buttons/settings-warn-rules.js
+++ b/src/components/buttons/settings-warn-rules.js
@@ -15,8 +15,12 @@ module.exports = {
     const guildId = interaction.guildId;
     
     // Parse page number from args (format: settings:warn-config:page:2)
-    const pageArg = args.find(arg => arg?.startsWith('page:'));
-    const requestedPage = pageArg ? parseInt(pageArg.split(':')[1]) : 1;
+    let requestedPage = 1;
+    const pageIndex = args.indexOf('page');
+    if (pageIndex !== -1) {
+      const parsed = parseInt(args[pageIndex + 1]);
+      if (!isNaN(parsed)) requestedPage = parsed;
+    }
     
     // Get warn reasons from database
     const warnReasons = await client.prisma.warnReason.findMany({

--- a/src/components/modals/settings-warn-create-rule-modal.js
+++ b/src/components/modals/settings-warn-create-rule-modal.js
@@ -1,0 +1,51 @@
+const {
+  MessageFlags,
+} = require('discord.js');
+
+module.exports = {
+  customId: 'settings:warn-create-rule-modal',
+
+  async execute(interaction, args, client) {
+    const messageId = args[0];
+    const label = interaction.fields.getTextInputValue('label').trim();
+    const guildId = interaction.guildId;
+
+    if (!label) {
+      return interaction.reply({
+        content: '❌ Название правила не может быть пустым.',
+        flags: MessageFlags.Ephemeral
+      });
+    }
+
+    try {
+      await client.prisma.warnReason.create({
+        data: { guildId, label }
+      });
+    } catch (error) {
+      return interaction.reply({
+        content: '❌ Не удалось создать правило. Возможно, такое название уже существует.',
+        flags: MessageFlags.Ephemeral
+      });
+    }
+
+    const ITEMS_PER_PAGE = 5;
+    const totalItems = await client.prisma.warnReason.count({ where: { guildId } });
+    const totalPages = Math.max(1, Math.ceil(totalItems / ITEMS_PER_PAGE));
+
+    try {
+      const message = await interaction.channel.messages.fetch(messageId);
+      const fakeInteraction = {
+        guildId,
+        update: (data) => message.edit(data)
+      };
+      await client.components.get('settings:warn-config').execute(fakeInteraction, [`page:${totalPages}`], client);
+    } catch (err) {
+      // ignore message update errors
+    }
+
+    await interaction.reply({
+      content: '✅ Правило создано.',
+      flags: MessageFlags.Ephemeral
+    });
+  }
+};


### PR DESCRIPTION
## Summary
- fix warn-config pagination to parse page args correctly
- enable creation of warn rules via modal and database update

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bab0ffd8b4832b8bbd50660d25bd2d