### PR TITLE
Fix customId parsing for settings components

### DIFF
--- a/src/components/modals/settings-warn-create-rule-modal.js
+++ b/src/components/modals/settings-warn-create-rule-modal.js
@@ -28,8 +28,18 @@ module.exports = {
         data: { guildId, label }
       });
     } catch (error) {
+      if (error?.code === 'P2002') {
+        // Unique constraint failed (duplicate label within guild)
+        return interaction.reply({
+          content: '❌ Не удалось создать правило. Такое название уже существует.',
+          flags: MessageFlags.Ephemeral
+        });
+      }
+
+      // Log unexpected errors for easier debugging
+      console.error('Failed to create warn reason:', error);
       return interaction.reply({
-        content: '❌ Не удалось создать правило. Возможно, такое название уже существует.',
+        content: '❌ Произошла внутренняя ошибка при создании правила.',
         flags: MessageFlags.Ephemeral
       });
     }

--- a/src/utils/ComponentHandler.js
+++ b/src/utils/ComponentHandler.js
@@ -12,14 +12,16 @@ function parseCustomId(customId) {
     if (customId.includes(':')) {
         const parts = customId.split(':');
         
-        // For simple patterns like 'settings:warn-config', the whole string is the baseId
-        if (parts.length <= 2) {
-            // Check if the second part contains a dash (indicating parameters)
-            if (parts.length === 2 && parts[1].includes('-')) {
-                // Split the second part by dash
-                const [secondPart, ...dashArgs] = parts[1].split('-');
-                const baseId = `${parts[0]}:${secondPart}`;
-                return { baseId, args: dashArgs };
+        // For simple patterns like 'settings:warn-config', treat the whole
+        // string as the base ID unless the last segment after '-' is numeric
+        // (e.g. 'settings:warn-edit-rule-123')
+        if (parts.length === 2) {
+            const subparts = parts[1].split('-');
+            const last = subparts[subparts.length - 1];
+
+            if (subparts.length > 1 && !isNaN(Number(last))) {
+                const baseId = `${parts[0]}:${subparts.slice(0, -1).join('-')}`;
+                return { baseId, args: [last] };
             }
             return { baseId: customId, args: [] };
         }


### PR DESCRIPTION
## Summary
- refine custom ID parsing to keep settings IDs intact and only treat numeric suffixes as arguments
- improve warn rule creation error handling by distinguishing duplicates and logging unexpected issues

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bac09acd40832ba0542a3bf91fe796