### PR TITLE
feat: add duration controls for warn punishments

### DIFF
--- a/src/components/buttons/settings-warn-duration-set.js
+++ b/src/components/buttons/settings-warn-duration-set.js
@@ -1,0 +1,55 @@
+const { MessageFlags } = require('discord.js');
+
+module.exports = {
+  customId: 'settings:warn-duration-set',
+
+  async execute(interaction, args, client) {
+    const [reasonId, minutes] = args;
+
+    if (!reasonId || !minutes) {
+      return interaction.reply({
+        content: '❌ Ошибка: неверные параметры.',
+        flags: MessageFlags.Ephemeral
+      });
+    }
+
+    const duration = parseInt(minutes, 10);
+    if (isNaN(duration) || duration <= 0) {
+      return interaction.reply({
+        content: '❌ Некорректная длительность.',
+        flags: MessageFlags.Ephemeral
+      });
+    }
+
+    const guildId = interaction.guildId;
+
+    try {
+      await client.prisma.warnReason.update({
+        where: {
+          id: parseInt(reasonId),
+          guildId
+        },
+        data: {
+          punishmentDurationMin: duration
+        }
+      });
+
+      const editRule = client.components.get('settings:warn-edit-rule');
+      if (editRule) {
+        await editRule.execute(interaction, [reasonId], client);
+      } else {
+        await interaction.reply({
+          content: '✅ Длительность установлена.',
+          flags: MessageFlags.Ephemeral
+        });
+      }
+    } catch (error) {
+      client.logs.error?.(`Duration set error: ${error.message}`);
+      await interaction.reply({
+        content: '❌ Ошибка при установке длительности.',
+        flags: MessageFlags.Ephemeral
+      });
+    }
+  }
+};
+

--- a/src/components/buttons/settings-warn-edit-duration.js
+++ b/src/components/buttons/settings-warn-edit-duration.js
@@ -1,19 +1,22 @@
-const { 
-  MessageFlags, 
-  ButtonStyle, 
+const {
+  MessageFlags,
+  ButtonStyle,
   ButtonBuilder,
   ActionRowBuilder,
   ContainerBuilder,
   SectionBuilder,
-  TextDisplayBuilder
+  TextDisplayBuilder,
+  ModalBuilder,
+  TextInputBuilder,
+  TextInputStyle
 } = require('discord.js');
 
 module.exports = {
   customId: 'settings:warn-edit-duration',
-  
+
   async execute(interaction, args, client) {
     const reasonId = args[0];
-    
+
     if (!reasonId) {
       return interaction.reply({
         content: '❌ Ошибка: не удалось определить ID правила.',
@@ -22,12 +25,11 @@ module.exports = {
     }
 
     const guildId = interaction.guildId;
-    
-    // Get current warn reason from database
+
     const warnReason = await client.prisma.warnReason.findUnique({
-      where: { 
+      where: {
         id: parseInt(reasonId),
-        guildId: guildId 
+        guildId: guildId
       }
     }).catch(() => null);
 
@@ -38,90 +40,84 @@ module.exports = {
       });
     }
 
-    const currentDuration = warnReason.punishmentDurationMin || 0;
-    const durationText = currentDuration > 0 ? `${currentDuration} мин` : 'не установлено';
+    // Handle mute: open modal to input minutes
+    if (warnReason.punishmentType === 'Mute') {
+      const modal = new ModalBuilder()
+        .setCustomId(`settings:warn-set-duration-modal:${interaction.message.id}:${reasonId}`)
+        .setTitle('Установить длительность');
 
-    // Build duration edit interface
-    const durationContainer = new ContainerBuilder()
-      .addActionRowComponents(
-        new ActionRowBuilder()
-          .addComponents(
+      const input = new TextInputBuilder()
+        .setCustomId('duration')
+        .setLabel('Длительность (мин)')
+        .setStyle(TextInputStyle.Short)
+        .setRequired(true);
+
+      modal.addComponents(new ActionRowBuilder().addComponents(input));
+
+      return interaction.showModal(modal);
+    }
+
+    // Handle timeout: show preset buttons
+    if (warnReason.punishmentType === 'Timeout') {
+      const durationContainer = new ContainerBuilder()
+        .addActionRowComponents(
+          new ActionRowBuilder().addComponents(
             new ButtonBuilder()
               .setStyle(ButtonStyle.Secondary)
-              .setLabel("← Назад")
+              .setLabel('← Назад')
               .setCustomId(`settings:warn-edit-rule-${reasonId}`)
           )
-      )
-      .addSectionComponents(
-        new SectionBuilder()
-          .setButtonAccessory(
-            new ButtonBuilder()
-              .setStyle(ButtonStyle.Primary)
-              .setLabel("⏰")
-              .setCustomId('settings:duration-info')
-              .setDisabled(true)
-          )
-          .addTextDisplayComponents(
-            new TextDisplayBuilder().setContent(
-              `> ### Длительность наказания для "${warnReason.label}"
-` +
-              `> Текущая длительность: **${durationText}**
-` +
-              `> Тип наказания: **${warnReason.punishmentType || 'None'}**
-` +
-              `> 
-` +
-              `> Используйте кнопки для изменения длительности:`
+        )
+        .addSectionComponents(
+          new SectionBuilder()
+            .setButtonAccessory(
+              new ButtonBuilder()
+                .setStyle(ButtonStyle.Secondary)
+                .setLabel('⏱')
+                .setCustomId('noop')
+                .setDisabled(true)
             )
+            .addTextDisplayComponents(
+              new TextDisplayBuilder().setContent(
+                `Длительность предупреждения: ${warnReason.punishmentDurationMin ? `${warnReason.punishmentDurationMin} мин` : 'не установлено'}`
+              )
+            )
+        )
+        .addActionRowComponents(
+          new ActionRowBuilder().addComponents(
+            new ButtonBuilder()
+              .setStyle(ButtonStyle.Secondary)
+              .setLabel('60 сек.')
+              .setCustomId(`settings:warn-duration-set:${reasonId}:1`),
+            new ButtonBuilder()
+              .setStyle(ButtonStyle.Secondary)
+              .setLabel('5 мин.')
+              .setCustomId(`settings:warn-duration-set:${reasonId}:5`),
+            new ButtonBuilder()
+              .setStyle(ButtonStyle.Secondary)
+              .setLabel('1 час.')
+              .setCustomId(`settings:warn-duration-set:${reasonId}:60`),
+            new ButtonBuilder()
+              .setStyle(ButtonStyle.Secondary)
+              .setLabel('1 день')
+              .setCustomId(`settings:warn-duration-set:${reasonId}:1440`),
+            new ButtonBuilder()
+              .setStyle(ButtonStyle.Secondary)
+              .setLabel('1 неделя')
+              .setCustomId(`settings:warn-duration-set:${reasonId}:10080`)
           )
-      )
-      .addActionRowComponents(
-        new ActionRowBuilder()
-          .addComponents(
-            new ButtonBuilder()
-              .setStyle(ButtonStyle.Secondary)
-              .setLabel('➖ 5 мин')
-              .setCustomId(`settings:duration-adjust-${reasonId}-dec-5`)
-              .setDisabled(currentDuration <= 5),
-            new ButtonBuilder()
-              .setStyle(ButtonStyle.Secondary)
-              .setLabel('➕ 5 мин')
-              .setCustomId(`settings:duration-adjust-${reasonId}-inc-5`),
-            new ButtonBuilder()
-              .setStyle(ButtonStyle.Secondary)
-              .setLabel('➖ 15 мин')
-              .setCustomId(`settings:duration-adjust-${reasonId}-dec-15`)
-              .setDisabled(currentDuration <= 15),
-            new ButtonBuilder()
-              .setStyle(ButtonStyle.Secondary)
-              .setLabel('➕ 15 мин')
-              .setCustomId(`settings:duration-adjust-${reasonId}-inc-15`)
-          )
-      )
-      .addActionRowComponents(
-        new ActionRowBuilder()
-          .addComponents(
-            new ButtonBuilder()
-              .setStyle(ButtonStyle.Secondary)
-              .setLabel('➖ 1 час')
-              .setCustomId(`settings:duration-adjust-${reasonId}-dec-60`)
-              .setDisabled(currentDuration <= 60),
-            new ButtonBuilder()
-              .setStyle(ButtonStyle.Secondary)
-              .setLabel('➕ 1 час')
-              .setCustomId(`settings:duration-adjust-${reasonId}-inc-60`),
-            new ButtonBuilder()
-              .setStyle(ButtonStyle.Danger)
-              .setLabel('🗑️ Сбросить')
-              .setCustomId(`settings:duration-reset-${reasonId}`)
-              .setDisabled(currentDuration === 0)
-          )
-      );
+        );
 
-    // Update the interaction with duration edit interface
-    await interaction.update({
-      components: [durationContainer],
-      flags: MessageFlags.IsComponentsV2
+      return interaction.update({
+        components: [durationContainer],
+        flags: MessageFlags.IsComponentsV2
+      });
+    }
+
+    return interaction.reply({
+      content: '❌ Тип наказания не поддерживает установку длительности.',
+      flags: MessageFlags.Ephemeral
     });
   }
 };
+

--- a/src/components/modals/settings-warn-set-duration-modal.js
+++ b/src/components/modals/settings-warn-set-duration-modal.js
@@ -1,0 +1,53 @@
+const { MessageFlags } = require('discord.js');
+
+module.exports = {
+  customId: 'settings:warn-set-duration-modal',
+
+  async execute(interaction, args, client) {
+    const [messageId, reasonId] = args;
+    const guildId = interaction.guildId;
+
+    const minutes = parseInt(interaction.fields.getTextInputValue('duration'), 10);
+    if (isNaN(minutes) || minutes <= 0) {
+      return interaction.reply({
+        content: '❌ Некорректная длительность.',
+        flags: MessageFlags.Ephemeral
+      });
+    }
+
+    try {
+      await client.prisma.warnReason.update({
+        where: {
+          id: parseInt(reasonId),
+          guildId
+        },
+        data: {
+          punishmentDurationMin: minutes
+        }
+      });
+
+      if (messageId) {
+        const message = await interaction.channel?.messages.fetch(messageId).catch(() => null);
+        if (message) {
+          const fakeInteraction = { guildId, update: (data) => message.edit(data) };
+          const editRule = client.components.get('settings:warn-edit-rule');
+          if (editRule) {
+            await editRule.execute(fakeInteraction, [reasonId], client);
+          }
+        }
+      }
+
+      await interaction.reply({
+        content: '✅ Длительность установлена.',
+        flags: MessageFlags.Ephemeral
+      });
+    } catch (error) {
+      client.logs.error?.(`Duration set error: ${error.message}`);
+      await interaction.reply({
+        content: '❌ Ошибка при установке длительности.',
+        flags: MessageFlags.Ephemeral
+      });
+    }
+  }
+};
+


### PR DESCRIPTION
## Summary
- add modal to input mute duration
- add preset timeout buttons for warn duration
- handle button and modal submissions to store duration
- fix timeout recognition to enable duration buttons
- add placeholder accessory in duration section to satisfy component builder

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check src/components/buttons/settings-warn-edit-duration.js`
- `node --check src/components/buttons/settings-warn-duration-set.js`
- `node --check src/components/modals/settings-warn-set-duration-modal.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb4a4d1138832b977a454776b428c3