### PR TITLE
Implement warn reason name and description editing

### DIFF
--- a/prisma/migrations/20250909162337_add_warn_reason_description/migration.sql
+++ b/prisma/migrations/20250909162337_add_warn_reason_description/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "WarnReason" ADD COLUMN "description" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -149,6 +149,7 @@ model WarnReason {
   id        Int      @id @default(autoincrement())
   guildId   String
   label     String   // text shown in UI
+  description String?
   active    Boolean  @default(true)
   createdAt DateTime @default(now())
 

--- a/src/components/buttons/settings-warn-edit-name.js
+++ b/src/components/buttons/settings-warn-edit-name.js
@@ -1,15 +1,62 @@
-const { MessageFlags } = require('discord.js');
+const {
+  MessageFlags,
+  ModalBuilder,
+  TextInputBuilder,
+  TextInputStyle,
+  ActionRowBuilder
+} = require('discord.js');
 
 module.exports = {
   customId: 'settings:warn-edit-name',
-  
+
   async execute(interaction, args, client) {
     const reasonId = args[0];
-    
-    // Placeholder for editing warn rule name/description
-    await interaction.reply({
-      content: `✏️ Функция редактирования названия и описания предупреждения (ID: ${reasonId}) находится в разработке.`,
-      flags: MessageFlags.Ephemeral
-    });
+
+    if (!reasonId) {
+      return interaction.reply({
+        content: '❌ Ошибка: не удалось определить ID правила.',
+        flags: MessageFlags.Ephemeral
+      });
+    }
+
+    const guildId = interaction.guildId;
+    const warnReason = await client.prisma.warnReason.findUnique({
+      where: {
+        id: parseInt(reasonId),
+        guildId
+      }
+    }).catch(() => null);
+
+    if (!warnReason) {
+      return interaction.reply({
+        content: '❌ Ошибка: правило не найдено.',
+        flags: MessageFlags.Ephemeral
+      });
+    }
+
+    const modal = new ModalBuilder()
+      .setCustomId(`settings:warn-edit-name-modal:${interaction.message?.id || ''}:${reasonId}`)
+      .setTitle('Редактировать предупреждение');
+
+    const nameInput = new TextInputBuilder()
+      .setCustomId('label')
+      .setLabel('Название')
+      .setStyle(TextInputStyle.Short)
+      .setRequired(true)
+      .setValue(warnReason.label);
+
+    const descInput = new TextInputBuilder()
+      .setCustomId('description')
+      .setLabel('Описание')
+      .setStyle(TextInputStyle.Paragraph)
+      .setRequired(false)
+      .setValue(warnReason.description || '');
+
+    modal.addComponents(
+      new ActionRowBuilder().addComponents(nameInput),
+      new ActionRowBuilder().addComponents(descInput)
+    );
+
+    await interaction.showModal(modal);
   }
 };

--- a/src/components/modals/settings-warn-edit-name-modal.js
+++ b/src/components/modals/settings-warn-edit-name-modal.js
@@ -1,0 +1,55 @@
+const { MessageFlags } = require('discord.js');
+
+module.exports = {
+  customId: 'settings:warn-edit-name-modal',
+
+  async execute(interaction, args, client) {
+    const [messageId, reasonId] = args;
+    const guildId = interaction.guildId;
+
+    const label = interaction.fields.getTextInputValue('label').trim();
+    const description = interaction.fields.getTextInputValue('description').trim();
+
+    if (!label) {
+      return interaction.reply({
+        content: '❌ Название правила не может быть пустым.',
+        flags: MessageFlags.Ephemeral
+      });
+    }
+
+    try {
+      await client.prisma.warnReason.update({
+        where: { id: parseInt(reasonId), guildId },
+        data: { label, description: description || null }
+      });
+
+      if (messageId) {
+        const message = await interaction.channel?.messages.fetch(messageId).catch(() => null);
+        if (message) {
+          const fakeInteraction = { guildId, update: (data) => message.edit(data) };
+          const editRule = client.components.get('settings:warn-edit-rule');
+          if (editRule) {
+            await editRule.execute(fakeInteraction, [reasonId], client);
+          }
+        }
+      }
+
+      await interaction.reply({
+        content: '✅ Правило обновлено.',
+        flags: MessageFlags.Ephemeral
+      });
+    } catch (error) {
+      if (error?.code === 'P2002') {
+        return interaction.reply({
+          content: '❌ Такое название уже существует.',
+          flags: MessageFlags.Ephemeral
+        });
+      }
+      client.logs?.error && client.logs.error(`Warn reason update error: ${error.message}`);
+      await interaction.reply({
+        content: '❌ Ошибка при обновлении правила.',
+        flags: MessageFlags.Ephemeral
+      });
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- add optional `description` to warn reasons schema
- implement modal to edit warn reason name and description
- persist updates and refresh rule configuration view

## Testing
- `npm run prisma:migrate:dev -- --name add_warn_reason_description`
- `npm run prisma:generate`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c0533fb0b8832bb058034bdb4d396d