### PR TITLE
feat: add detailed warning DM

### DIFF
--- a/src/modules/moderation/commands/warn.js
+++ b/src/modules/moderation/commands/warn.js
@@ -169,16 +169,27 @@ module.exports = {
     }
 
     try {
+      const expiresTimestamp = expiresAt ? Math.floor(expiresAt.getTime() / 1000) : null;
+      const expiryFieldValue = expiresTimestamp
+        ? `Истекает\n> <t:${expiresTimestamp}:F>\n> <t:${expiresTimestamp}:R>`
+        : 'Не истекает';
+
       const dmEmbed = new EmbedBuilder()
         .setColor(0x2F3136)
         .setTitle('Предупреждение')
-        .setDescription(`⚠️ Вы получили предупреждение на сервере **${guild.name}**`)
+        .setDescription(`Вы получили предупреждение на сервере **${guild.name}**`)
         .addFields(
-          { name: 'Причина', value: reason.label, inline: false },
-          { name: 'Всего предупреждений', value: `${warnCount}`, inline: true }
+          { name: 'Причина', value: reason.label, inline: true },
+          {
+            name: 'Выдал',
+            value: `<@${moderator.id}>\n> ${moderator.user.tag}\n> ${moderator.id}`,
+            inline: true
+          },
+          { name: 'Время истечения предупреждения', value: expiryFieldValue, inline: true }
         )
+        .setFooter({ text: guild.name })
         .setTimestamp();
-      if (actionText) dmEmbed.addFields({ name: 'Действие', value: actionText, inline: true });
+
       await targetUser.send({ embeds: [dmEmbed] });
     } catch (e) {
       // ignore DM errors


### PR DESCRIPTION
## Summary
- detail DM warning embed with moderator and expiry info
- include moderator mention, tag, and ID in DM notification

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c1a0d753a0832ba04b3bfccf3ad80f